### PR TITLE
Added support for grid (dotted)

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -2157,9 +2157,11 @@ color: #aaa;
 }
 
 .red-ui-workspace-chart-grid line {
-  shape-rendering: auto;
-  stroke: #111;
-  stroke-width: 0.5px;
+  shape-rendering: optimizeSpeed;
+  stroke: #ffffff;
+  stroke-width: 1px;
+  stroke-opacity: 0.2;
+  stroke-dasharray: 0.2;
 }
 
 .red-ui-workspace-disabled.red-ui-tab a {


### PR DESCRIPTION
Currently the grid is not available in the team although grid checkbox is enabled,
with that fix, the grid will be dotted and very light,
In case someone would like to disabled the grid, the option is available via `Settings -> Grid` checkbox